### PR TITLE
Fix:타회원 포트폴리오 조회시 매수매도내역 없을때 예외처리 추가

### DIFF
--- a/src/main/java/com/TMT/TMT_BE_PortFolio/myportfolio/application/MyPortFolioServiceImp.java
+++ b/src/main/java/com/TMT/TMT_BE_PortFolio/myportfolio/application/MyPortFolioServiceImp.java
@@ -33,10 +33,10 @@ public class MyPortFolioServiceImp implements MyPortfolioService {
     @Override //MemberStock Read
     public List<HasStockResponseVo> getMyPortFolio(String uuid) {
         List<Tuple> tupleList = memberStockQueryDslImp.getStockInfo(uuid);
-        if (tupleList.isEmpty()) {
+        List<MemberStockDto> memberStockDto = tupleList.stream().map(this::maptoDto).toList();
+        if (memberStockDto.isEmpty()) {
             throw new CustomException(BaseResponseCode.EMPTY_STOCK);
         }
-        List<MemberStockDto> memberStockDto = tupleList.stream().map(this::maptoDto).toList();
         return stockInfoRead(memberStockDto);
     }
 
@@ -83,7 +83,6 @@ public class MyPortFolioServiceImp implements MyPortfolioService {
 
         FeignClientResponseMapperDto feignClientResponseMapperDto = sendNickname.sendNickname(nickname);
         FeignClientResponseDto feignClientResponseDto = feignClientResponseMapperDto.getData();
-
         log.info("feignClientResponseDtouuid ={} ",feignClientResponseDto.getNickname());
         log.info("feignClientResponseDtoNickname ={} ",feignClientResponseDto.getNickname());
         return sendUserHasStock(feignClientResponseDto);
@@ -96,12 +95,17 @@ public class MyPortFolioServiceImp implements MyPortfolioService {
         String uuid = feignClientResponseDto.getUuid();
         log.info("uuid ={} ",uuid);
         List<Tuple> tupleList = memberStockQueryDslImp.getStockInfo(uuid);
-        if (tupleList.isEmpty()) {
-            throw new CustomException(BaseResponseCode.EMPTY_STOCK);
-        }
         List<MemberStockDto> memberStockDto = tupleList.stream().map(this::maptoDto).toList();
         String nickName = feignClientResponseDto.getNickname();
         String grade = feignClientResponseDto.getGrade();
+
+        if (memberStockDto.isEmpty()) {
+            UserStockResponseVo hasStock = new UserStockResponseVo(nickName, grade,
+                    null, null, null);
+            List<UserStockResponseVo> userHasStock = new ArrayList<>();
+            userHasStock.add(hasStock);
+            return userHasStock;
+        }
 
         List<UserStockResponseVo> userHasStock = new ArrayList<>();
         for (MemberStockDto memberStockList : memberStockDto) {

--- a/src/main/java/com/TMT/TMT_BE_PortFolio/myportfolio/application/MyPortfolioService.java
+++ b/src/main/java/com/TMT/TMT_BE_PortFolio/myportfolio/application/MyPortfolioService.java
@@ -8,10 +8,6 @@ import java.util.List;
 
 public interface MyPortfolioService {
 
-    //MemberStock Read
-
-
-    //MemberStock Read
     List<HasStockResponseVo> getMyPortFolio(String uuid);
 
     List<HasStockResponseVo> stockInfoRead(List<MemberStockDto> memberStockDto);
@@ -20,4 +16,5 @@ public interface MyPortfolioService {
 
     List<UserStockResponseVo> sendUserHasStock(FeignClientResponseDto
             feignClientResponseDto);
+
 }


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) feat : pull request template#17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 패키징 구조 변경
- [ ] 파일명 변경
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [ ] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용

<!--@{Issue번호} + Enter
ex) @17
이슈와 PR 연결을 위해 사용합니다!-->

- 매수매도 데이터가 없을때 닉네임, 등급만 반환되도록 수정했습니다.

  <br/>

## 📈이미지 첨부
- 이미지 첨부가 필요한 경우 첨부 해주세요!
  <br/>
<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 과제

해당 이슈의 To do list를 작성 해주세요!
- [ ] Refresh Token 발급 절차 신규 적용 에정.
- [ ] User Login 절차 검증 로직 추가 및 리팩토링
